### PR TITLE
fix: query energy forecast for future window

### DIFF
--- a/lib/queryTimeRanges.js
+++ b/lib/queryTimeRanges.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Returns the start of a local calendar day.
+ *
+ * @param {Date} date
+ * @param {number} dayOffset
+ */
+function getLocalDayStart(date, dayOffset = 0) {
+  const dayStart = new Date(date);
+  dayStart.setHours(0, 0, 0, 0);
+  dayStart.setDate(dayStart.getDate() + dayOffset);
+  return dayStart.getTime();
+}
+
+/**
+ * Builds the time windows used for Solar.web endpoints with from/to query
+ * parameters.
+ *
+ * Historical data and the energy forecast use different windows:
+ * - historical data looks into the past,
+ * - energy forecast is requested per local calendar day.
+ *
+ * Solar.web rejects ranges larger than 24 hours, so today and tomorrow are
+ * requested as separate windows.
+ *
+ * @param {Date} date
+ */
+function getQueryTimeRanges(date) {
+  const now = date.getTime();
+  const forecastTodayFrom = getLocalDayStart(date, 0);
+  const forecastTomorrowFrom = getLocalDayStart(date, 1);
+
+  return {
+    now,
+    historyFrom: now + 5000 - ONE_DAY_MS,
+    forecastTodayFrom,
+    forecastTodayTo: forecastTodayFrom + ONE_DAY_MS,
+    forecastTomorrowFrom,
+    forecastTomorrowTo: forecastTomorrowFrom + ONE_DAY_MS,
+  };
+}
+
+module.exports = {
+  getQueryTimeRanges,
+};

--- a/main.js
+++ b/main.js
@@ -9,6 +9,7 @@
 const utils = require('@iobroker/adapter-core');
 const axios = require('axios');
 const Json2iob = require('json2iob');
+const { getQueryTimeRanges } = require('./lib/queryTimeRanges');
 
 class FroniusSolarweb extends utils.Adapter {
   /**
@@ -194,7 +195,7 @@ class FroniusSolarweb extends utils.Adapter {
     const year = date.getFullYear();
     const month = date.getMonth() + 1;
     const day = date.getDate();
-    const toDate = new Date(date.getTime() + 5000 - 24 * 60 * 60 * 1000);
+    const queryRanges = getQueryTimeRanges(date);
     const statusArray = [
       {
         path: 'flowdata',
@@ -203,7 +204,11 @@ class FroniusSolarweb extends utils.Adapter {
       },
       {
         path: 'histdata',
-        url: 'https://swqapi.solarweb.com/pvsystems/$id/histdata?from=' + toDate.getTime() + '&to=' + Date.now(),
+        url:
+          'https://swqapi.solarweb.com/pvsystems/$id/histdata?from=' +
+          queryRanges.historyFrom +
+          '&to=' +
+          queryRanges.now,
         desc: 'Historical Data',
         forceIndex: true,
       },
@@ -253,8 +258,22 @@ class FroniusSolarweb extends utils.Adapter {
     if (this.isPro) {
       statusArray.push({
         path: 'energyforecast',
-        url: 'https://swqapi.solarweb.com/pvsystems/$id/weather/energyforecast?from=' + toDate.getTime() + '&to=' + Date.now(),
-        desc: 'Energy Forecast',
+        url:
+          'https://swqapi.solarweb.com/pvsystems/$id/weather/energyforecast?from=' +
+          queryRanges.forecastTodayFrom +
+          '&to=' +
+          queryRanges.forecastTodayTo,
+        desc: 'Energy Forecast Today',
+        forceIndex: true,
+      });
+      statusArray.push({
+        path: 'energyforecastTomorrow',
+        url:
+          'https://swqapi.solarweb.com/pvsystems/$id/weather/energyforecast?from=' +
+          queryRanges.forecastTomorrowFrom +
+          '&to=' +
+          queryRanges.forecastTomorrowTo,
+        desc: 'Energy Forecast Tomorrow',
         forceIndex: true,
       });
     }

--- a/main.test.js
+++ b/main.test.js
@@ -1,29 +1,30 @@
 'use strict';
 
-/**
- * This is a dummy TypeScript test file using chai and mocha
- *
- * It's automatically excluded from npm and its build output is excluded from both git and npm.
- * It is advised to test all your modules with accompanying *.test.js-files
- */
+const assert = require('assert');
+const { getQueryTimeRanges } = require('./lib/queryTimeRanges');
 
-// tslint:disable:no-unused-expression
+describe('Solar.web query time ranges', () => {
+  it('uses the past 24 hours for historical data', () => {
+    const now = new Date('2026-05-13T10:00:00.000Z');
+    const ranges = getQueryTimeRanges(now);
 
-const { expect } = require('chai');
-// import { functionToTest } from "./moduleToTest";
-
-describe('module to test => function to test', () => {
-  // initializing logic
-  const expected = 5;
-
-  it(`should return ${expected}`, () => {
-    const result = 5;
-    // assign result a value from functionToTest
-    expect(result).to.equal(expected);
-    // or using the should() syntax
-    result.should.equal(expected);
+    assert.equal(ranges.now, now.getTime());
+    assert.equal(ranges.historyFrom, now.getTime() + 5000 - 24 * 60 * 60 * 1000);
+    assert.ok(ranges.historyFrom < ranges.now);
   });
-  // ... more tests => it
-});
 
-// ... more test suites => describe
+  it('uses separate local calendar-day windows for today and tomorrow forecasts', () => {
+    const now = new Date('2026-05-13T10:00:00.000Z');
+    const ranges = getQueryTimeRanges(now);
+
+    const expectedTodayStart = new Date(now);
+    expectedTodayStart.setHours(0, 0, 0, 0);
+    const expectedTomorrowStart = new Date(expectedTodayStart);
+    expectedTomorrowStart.setDate(expectedTomorrowStart.getDate() + 1);
+
+    assert.equal(ranges.forecastTodayFrom, expectedTodayStart.getTime());
+    assert.equal(ranges.forecastTodayTo, expectedTodayStart.getTime() + 24 * 60 * 60 * 1000);
+    assert.equal(ranges.forecastTomorrowFrom, expectedTomorrowStart.getTime());
+    assert.equal(ranges.forecastTomorrowTo, expectedTomorrowStart.getTime() + 24 * 60 * 60 * 1000);
+  });
+});

--- a/test/mocha.setup.js
+++ b/test/mocha.setup.js
@@ -2,13 +2,3 @@
 process.on('unhandledRejection', (e) => {
   throw e;
 });
-
-// enable the should interface with sinon
-// and load chai-as-promised and sinon-chai by default
-const sinonChai = require('sinon-chai');
-const chaiAsPromised = require('chai-as-promised');
-const { should, use } = require('chai');
-
-should();
-use(sinonChai);
-use(chaiAsPromised);


### PR DESCRIPTION
## Zusammenfassung

Dieser PR behebt die Abfrage des Solar.web-`energyforecast`-Endpunkts.

Bisher wurde für `energyforecast` derselbe Zeitraum wie für `histdata` verwendet:

```text
from = jetzt - 24h
to   = jetzt
```

Bei einer Solar.web-Premium-/Pro-Anlage liefert dieser Zeitraum zwar HTTP `200`, aber ein leeres `data`-Array. Dadurch wurde nur der Channel `energyforecast` angelegt, aber keine Forecast-Werte darunter.

Der Forecast-Endpunkt liefert die erwarteten Daten, wenn Forecast-Zeiträume in die Zukunft bzw. als lokale Kalendertage abgefragt werden. Da Solar.web Bereiche größer als 24 Stunden ablehnt, trennt der PR die Forecasts in zwei Requests:

```text
energyforecast          = lokaler aktueller Kalendertag
energyforecastTomorrow  = lokaler nächster Kalendertag
```

## Änderungen

- Zeitfenster-Logik in `lib/queryTimeRanges.js` ausgelagert.
- `histdata` nutzt weiterhin den vergangenen 24h-Zeitraum.
- `energyforecast` nutzt jetzt den lokalen aktuellen Kalendertag.
- `energyforecastTomorrow` nutzt den lokalen nächsten Kalendertag.
- Dummy-Test durch echte Tests für die Zeitfenster ersetzt.
- Test-Setup bereinigt, damit keine nicht deklarierten Chai-Plugins benötigt werden.

## Praxistest

Ich konnte das Verhalten in einer realen Solar.web-Premium-Umgebung nachvollziehen:

- vorher: `energyforecast` mit Vergangenheitsfenster → HTTP `200`, aber leeres `data`-Array
- `now` bis `now + 24h` → HTTP `200`, Forecast-Datensätze werden angelegt
- lokaler aktueller Kalendertag → HTTP `200`, Forecast-Datensätze werden angelegt
- lokaler nächster Kalendertag → HTTP `200`, Forecast-Datensätze werden angelegt
- aktueller Tag bis Ende nächster Tag in einem Request → HTTP `400`, Bereich zu groß

## Tests

```bash
node --check main.js
node --check lib/queryTimeRanges.js
npm test
npm run lint -- .
```

Zusätzlich geprüft:

```bash
npm run check
```

Dieser Check schlägt aktuell unabhängig von dieser Änderung fehl, u. a. wegen bestehender Typ-/Dependency-Probleme in der Projektkonfiguration (`axios.create`, fehlende Mocha-/Sinon-Typen in `@iobroker/testing`).

Fixes #4
