### PR TITLE
Stabile Energy-Forecast-Datenpunkte ergänzen

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,26 @@ Adapter for Fronius Solarweb Portal
 
 Die solarWeb Mail und Passwort eingeben.
 
+## Energy-Forecast
+
+Wenn für die Solar.web-Anlage die Energy-Forecast-/Pro-Daten verfügbar sind, liest der Adapter den aktuellen und den nächsten lokalen Kalendertag aus:
+
+- `energyforecast`: Rohdaten für den heutigen lokalen Kalendertag.
+- `energyforecastTomorrow`: Rohdaten für den morgigen lokalen Kalendertag.
+
+Da Fronius je nach Zeitpunkt unterschiedliche Granularitäten liefert, erzeugt der Adapter zusätzlich stabile, normalisierte Datenpunkte:
+
+- `energyforecastToday15m.*.value`: 96 feste 15-Minuten-Slots für heute.
+- `energyforecastTomorrowHourly.*.value`: 24 feste Stunden-Slots für morgen.
+- `energyforecastSummary.todayWh`: Summe der heutigen Prognose in Wh.
+- `energyforecastSummary.todayRemainingWh`: verbleibende Prognose für heute in Wh. Dieser Wert wird minütlich aus den stabilen 15-Minuten-Slots aktualisiert und berücksichtigt den angebrochenen aktuellen Slot anteilig.
+- `energyforecastSummary.tomorrowWh`: Summe der morgigen Prognose in Wh.
+- `energyforecastSummary.recordCount`: Anzahl der zuletzt gelesenen Rohdatensätze für heute und morgen.
+
+Die vorhandenen kompakten Summary-States `todayWh`, `todayRemainingWh` und `tomorrowWh` bleiben zusätzlich erhalten. `todayRemainingWh` wird ebenfalls minütlich aktualisiert.
+
+Beim Aktualisieren der Rohdaten markiert der Adapter außerdem Index-Objekte aus vorherigen, längeren Forecast-Antworten als veraltet. Dafür werden pro Rohdatenzeile Metadaten wie `valid`, `stale`, `lastSeenInResponseAt` und `staleSince` gepflegt. Die Rohdatenobjekte werden nicht gelöscht, damit vorhandene ioBroker-Custom-Settings, z. B. History-/SQL-Konfigurationen, erhalten bleiben.
+
 ## Diskussion und Fragen
 
 <https://forum.iobroker.net/topic/51550/test-adapter-fronius-solarweb>

--- a/energyForecast.test.js
+++ b/energyForecast.test.js
@@ -1,0 +1,120 @@
+// @ts-nocheck
+'use strict';
+
+const assert = require('assert');
+const { calculateTodayRemainingFromSlots, getForecastRowValidityUpdates, normalizeEnergyForecast } = require('./lib/energyForecast');
+
+function record(logDateTime, logDuration, value) {
+  return {
+    logDateTime,
+    logDuration,
+    channels: [
+      {
+        channelName: 'EnergyExpected',
+        value,
+      },
+    ],
+  };
+}
+
+describe('energy forecast normalization', () => {
+  it('aggregates tomorrow 15-minute and hourly records into stable hourly slots', () => {
+    const now = new Date(2026, 4, 13, 12, 0, 0);
+    const normalized = normalizeEnergyForecast(
+      [],
+      [
+        record('2026-05-14T00:00:00', 900, 10),
+        record('2026-05-14T00:15:00', 900, 20),
+        record('2026-05-14T00:30:00', 900, 30),
+        record('2026-05-14T00:45:00', 900, 40),
+        record('2026-05-14T01:00:00', 3600, 200),
+      ],
+      now,
+    );
+
+    assert.strictEqual(normalized.tomorrowHourly.find((slot) => slot.label === '00').value, 100);
+    assert.strictEqual(normalized.tomorrowHourly.find((slot) => slot.label === '01').value, 200);
+    assert.strictEqual(normalized.summary.tomorrowWh, 300);
+    assert.strictEqual(normalized.summary.recordCount, 5);
+  });
+
+  it('splits hourly today records into stable 15-minute slots', () => {
+    const now = new Date(2026, 4, 13, 0, 0, 0);
+    const normalized = normalizeEnergyForecast(
+      [record('2026-05-13T01:00:00', 3600, 60)],
+      [],
+      now,
+    );
+
+    for (const label of ['01_00', '01_15', '01_30', '01_45']) {
+      assert.strictEqual(normalized.today15m.find((slot) => slot.label === label).value, 15);
+    }
+    assert.strictEqual(normalized.summary.todayWh, 60);
+  });
+
+  it('keeps only the overlapping part of records at day boundaries', () => {
+    const now = new Date(2026, 4, 13, 0, 0, 0);
+    const normalized = normalizeEnergyForecast(
+      [record('2026-05-12T23:45:00', 3600, 40)],
+      [],
+      now,
+    );
+
+    assert.strictEqual(normalized.today15m.find((slot) => slot.label === '00_00').value, 10);
+    assert.strictEqual(normalized.today15m.find((slot) => slot.label === '00_15').value, 10);
+    assert.strictEqual(normalized.today15m.find((slot) => slot.label === '00_30').value, 10);
+    assert.strictEqual(normalized.summary.todayWh, 30);
+  });
+
+  it('calculates the remaining part of the current slot proportionally', () => {
+    const day = new Date(2026, 4, 13, 0, 0, 0);
+    const now = new Date(2026, 4, 13, 1, 5, 0);
+    const slots = [
+      {
+        start: new Date(day.getTime() + 60 * 60 * 1000),
+        end: new Date(day.getTime() + 75 * 60 * 1000),
+        value: 15,
+      },
+      {
+        start: new Date(day.getTime() + 75 * 60 * 1000),
+        end: new Date(day.getTime() + 90 * 60 * 1000),
+        value: 30,
+      },
+    ];
+
+    assert.strictEqual(calculateTodayRemainingFromSlots(slots, now), 40);
+  });
+
+  it('marks raw forecast rows outside the latest response as stale without deleting them', () => {
+    const updates = getForecastRowValidityUpdates(
+      [
+        'fronius-solarweb.0.plant.energyforecast.01.logDateTime',
+        'fronius-solarweb.0.plant.energyforecast.01.channels01.value',
+        'fronius-solarweb.0.plant.energyforecast.02.logDateTime',
+        'fronius-solarweb.0.plant.energyforecast.03.logDateTime',
+        'fronius-solarweb.0.plant.energyforecastSummary.todayWh',
+      ],
+      'plant.energyforecast',
+      'fronius-solarweb.0',
+      2,
+    );
+
+    assert.deepStrictEqual(updates, [
+      {
+        root: 'plant.energyforecast.01',
+        rowIndex: 1,
+        valid: true,
+      },
+      {
+        root: 'plant.energyforecast.02',
+        rowIndex: 2,
+        valid: true,
+      },
+      {
+        root: 'plant.energyforecast.03',
+        rowIndex: 3,
+        valid: false,
+      },
+    ]);
+  });
+});

--- a/lib/energyForecast.js
+++ b/lib/energyForecast.js
@@ -1,0 +1,182 @@
+'use strict';
+
+const QUARTER_HOUR_MINUTES = 15;
+const HOUR_MINUTES = 60;
+const MS_PER_MINUTE = 60 * 1000;
+
+function pad(n) {
+  return n.toString().padStart(2, '0');
+}
+
+function formatLocalDate(date) {
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+}
+
+function getLocalDayStart(date, dayOffset = 0) {
+  const dayStart = new Date(date);
+  dayStart.setHours(0, 0, 0, 0);
+  dayStart.setDate(dayStart.getDate() + dayOffset);
+  return dayStart;
+}
+
+function createSlots(dayStart, slotMinutes) {
+  const slots = [];
+  const slotsPerDay = (24 * HOUR_MINUTES) / slotMinutes;
+  for (let index = 0; index < slotsPerDay; index += 1) {
+    const start = new Date(dayStart.getTime() + index * slotMinutes * MS_PER_MINUTE);
+    const end = new Date(start.getTime() + slotMinutes * MS_PER_MINUTE);
+    const label = slotMinutes === HOUR_MINUTES ? pad(start.getHours()) : `${pad(start.getHours())}_${pad(start.getMinutes())}`;
+    slots.push({
+      label,
+      start,
+      end,
+      durationSeconds: slotMinutes * 60,
+      value: 0,
+    });
+  }
+  return slots;
+}
+
+function getEnergyExpected(record) {
+  if (!record || !Array.isArray(record.channels)) {
+    return null;
+  }
+
+  const channel = record.channels.find((item) => {
+    const name = item && item.channelName ? String(item.channelName) : '';
+    return /EnergyExpected|Expected|EnergyProduction|EnergyPV|PvEnergy|PV|Production/i.test(name);
+  });
+  const value = Number(channel && channel.value);
+  return Number.isFinite(value) ? value : null;
+}
+
+function addRecordToSlots(record, slots) {
+  const value = getEnergyExpected(record);
+  const durationSeconds = Number(record && record.logDuration);
+  const start = new Date(record && record.logDateTime);
+
+  if (value === null || !Number.isFinite(durationSeconds) || durationSeconds <= 0 || Number.isNaN(start.getTime())) {
+    return;
+  }
+
+  const end = new Date(start.getTime() + durationSeconds * 1000);
+
+  if (slots.length === 0 || end.getTime() <= slots[0].start.getTime() || start.getTime() >= slots[slots.length - 1].end.getTime()) {
+    return;
+  }
+
+  const durationMs = end.getTime() - start.getTime();
+  for (const slot of slots) {
+    const overlapStart = Math.max(start.getTime(), slot.start.getTime());
+    const overlapEnd = Math.min(end.getTime(), slot.end.getTime());
+    const overlapMs = overlapEnd - overlapStart;
+    if (overlapMs > 0) {
+      slot.value += value * (overlapMs / durationMs);
+    }
+  }
+}
+
+function roundEnergy(value) {
+  return Math.round(value * 1000) / 1000;
+}
+
+function calculateTodayRemainingFromSlots(todaySlots, now = new Date()) {
+  let remaining = 0;
+  for (const slot of todaySlots) {
+    if (slot.end.getTime() <= now.getTime()) {
+      continue;
+    }
+    if (slot.start.getTime() >= now.getTime()) {
+      remaining += slot.value;
+      continue;
+    }
+
+    const remainingMs = slot.end.getTime() - now.getTime();
+    const durationMs = slot.end.getTime() - slot.start.getTime();
+    if (remainingMs > 0 && durationMs > 0) {
+      remaining += slot.value * (remainingMs / durationMs);
+    }
+  }
+  return roundEnergy(remaining);
+}
+
+function normalizeEnergyForecast(todayRecords = [], tomorrowRecords = [], now = new Date()) {
+  const todayStart = getLocalDayStart(now, 0);
+  const tomorrowStart = getLocalDayStart(now, 1);
+  const todayDate = formatLocalDate(todayStart);
+  const tomorrowDate = formatLocalDate(tomorrowStart);
+  const today15m = createSlots(todayStart, QUARTER_HOUR_MINUTES);
+  const tomorrowHourly = createSlots(tomorrowStart, HOUR_MINUTES);
+
+  for (const record of Array.isArray(todayRecords) ? todayRecords : []) {
+    addRecordToSlots(record, today15m);
+  }
+  for (const record of Array.isArray(tomorrowRecords) ? tomorrowRecords : []) {
+    addRecordToSlots(record, tomorrowHourly);
+  }
+
+  for (const slot of today15m) {
+    slot.value = roundEnergy(slot.value);
+  }
+  for (const slot of tomorrowHourly) {
+    slot.value = roundEnergy(slot.value);
+  }
+
+  const todayWh = roundEnergy(today15m.reduce((sum, slot) => sum + slot.value, 0));
+  const tomorrowWh = roundEnergy(tomorrowHourly.reduce((sum, slot) => sum + slot.value, 0));
+
+  return {
+    todayDate,
+    tomorrowDate,
+    today15m,
+    tomorrowHourly,
+    summary: {
+      todayWh,
+      todayRemainingWh: calculateTodayRemainingFromSlots(today15m, now),
+      tomorrowWh,
+      recordCount: (Array.isArray(todayRecords) ? todayRecords.length : 0) + (Array.isArray(tomorrowRecords) ? tomorrowRecords.length : 0),
+      updatedAt: now.toISOString(),
+      remainingUpdatedAt: now.toISOString(),
+    },
+  };
+}
+
+function getForecastRowValidityUpdates(objectIds = [], basePath, namespace, currentLength) {
+  const indexedRows = new Map();
+  const namespacePrefix = namespace ? `${namespace}.` : '';
+
+  for (const objectId of Array.isArray(objectIds) ? objectIds : []) {
+    const relativeObjectId = namespacePrefix && objectId.startsWith(namespacePrefix) ? objectId.slice(namespacePrefix.length) : objectId;
+    if (!relativeObjectId || !relativeObjectId.startsWith(`${basePath}.`)) {
+      continue;
+    }
+
+    const match = relativeObjectId.slice(basePath.length + 1).match(/^(\d+)(?:\.|$)/);
+    if (!match) {
+      continue;
+    }
+
+    const rowIndex = Number(match[1]);
+    if (!Number.isFinite(rowIndex)) {
+      continue;
+    }
+
+    indexedRows.set(rowIndex, match[1]);
+  }
+
+  return Array.from(indexedRows.entries())
+    .sort(([leftIndex], [rightIndex]) => leftIndex - rightIndex)
+    .map(([rowIndex, rowKey]) => ({
+      root: `${basePath}.${rowKey}`,
+      rowIndex,
+      valid: rowIndex <= currentLength,
+    }));
+}
+
+module.exports = {
+  calculateTodayRemainingFromSlots,
+  formatLocalDate,
+  getForecastRowValidityUpdates,
+  getLocalDayStart,
+  normalizeEnergyForecast,
+};

--- a/main.js
+++ b/main.js
@@ -10,6 +10,13 @@ const utils = require('@iobroker/adapter-core');
 const axios = require('axios');
 const Json2iob = require('json2iob');
 const { getQueryTimeRanges } = require('./lib/queryTimeRanges');
+const {
+  calculateTodayRemainingFromSlots,
+  formatLocalDate,
+  getForecastRowValidityUpdates,
+  getLocalDayStart,
+  normalizeEnergyForecast,
+} = require('./lib/energyForecast');
 
 class FroniusSolarweb extends utils.Adapter {
   /**
@@ -40,6 +47,7 @@ class FroniusSolarweb extends utils.Adapter {
     this.updateInterval = null;
     this.reLoginTimeout = null;
     this.refreshTokenTimeout = null;
+    this.remainingForecastInterval = null;
     this.session = {};
   }
 
@@ -71,6 +79,9 @@ class FroniusSolarweb extends utils.Adapter {
       this.refreshTokenInterval = setInterval(() => {
         this.refreshToken();
       }, 3432 * 1000);
+      this.remainingForecastInterval = setInterval(() => {
+        this.updateEnergyForecastRemainingSummaries();
+      }, 60 * 1000);
     }
   }
   async login() {
@@ -267,9 +278,6 @@ class FroniusSolarweb extends utils.Adapter {
           '&timezone=local',
         desc: 'Energy Forecast Today',
         forceIndex: true,
-        deleteBeforeUpdate: true,
-        summaryState: 'todayWh',
-        remainingState: 'todayRemainingWh',
       });
       statusArray.push({
         path: 'energyforecastTomorrow',
@@ -281,12 +289,11 @@ class FroniusSolarweb extends utils.Adapter {
           '&timezone=local',
         desc: 'Energy Forecast Tomorrow',
         forceIndex: true,
-        deleteBeforeUpdate: true,
-        summaryState: 'tomorrowWh',
       });
     }
 
     for (const id of this.deviceArray) {
+      const energyForecastResponses = {};
       for (const element of statusArray) {
         const url = element.url.replace('$id', id);
 
@@ -303,60 +310,20 @@ class FroniusSolarweb extends utils.Adapter {
               return;
             }
             const data = res.data.data;
+            const isEnergyForecast = element.path === 'energyforecast' || element.path === 'energyforecastTomorrow';
+
+            if (isEnergyForecast) {
+              energyForecastResponses[element.path] = Array.isArray(data) ? data : [];
+            }
 
             await this.json2iob.parse(id + '.' + element.path, data, {
               forceIndex: element.forceIndex,
               preferedArrayName: 'channelName',
               channelName: element.desc,
-              deleteBeforeUpdate: element.deleteBeforeUpdate,
             });
 
-            if (element.summaryState && Array.isArray(data)) {
-              let sum = 0;
-              let remaining = 0;
-              const now = new Date();
-              for (const entry of data) {
-                if (!Array.isArray(entry.channels)) continue;
-                for (const ch of entry.channels) {
-                  if (ch.channelName !== 'EnergyExpected' || typeof ch.value !== 'number') continue;
-                  sum += ch.value;
-                  if (element.remainingState && entry.logDateTime) {
-                    const slotEnd = new Date(entry.logDateTime);
-                    slotEnd.setSeconds(slotEnd.getSeconds() + (entry.logDuration || 0));
-                    if (slotEnd > now) {
-                      remaining += ch.value;
-                    }
-                  }
-                }
-              }
-              await this.setObjectNotExistsAsync(id + '.' + element.summaryState, {
-                type: 'state',
-                common: {
-                  name: element.desc + ' Total',
-                  type: 'number',
-                  role: 'value.energy',
-                  unit: 'Wh',
-                  read: true,
-                  write: false,
-                },
-                native: {},
-              });
-              await this.setStateAsync(id + '.' + element.summaryState, Math.round(sum), true);
-              if (element.remainingState) {
-                await this.setObjectNotExistsAsync(id + '.' + element.remainingState, {
-                  type: 'state',
-                  common: {
-                    name: element.desc + ' Remaining',
-                    type: 'number',
-                    role: 'value.energy',
-                    unit: 'Wh',
-                    read: true,
-                    write: false,
-                  },
-                  native: {},
-                });
-                await this.setStateAsync(id + '.' + element.remainingState, Math.round(remaining), true);
-              }
+            if (isEnergyForecast) {
+              await this.updateIndexedForecastValidityMetadata(id, element.path, Array.isArray(data) ? data.length : 0);
             }
           })
           .catch((error) => {
@@ -385,8 +352,177 @@ class FroniusSolarweb extends utils.Adapter {
             error.response && this.log.error(JSON.stringify(error.response.data));
           });
       }
+
+      if (energyForecastResponses.energyforecast || energyForecastResponses.energyforecastTomorrow) {
+        await this.writeNormalizedEnergyForecast(
+          id,
+          energyForecastResponses.energyforecast || [],
+          energyForecastResponses.energyforecastTomorrow || [],
+        );
+      }
     }
   }
+
+  async updateIndexedForecastValidityMetadata(deviceId, forecastPath, currentLength) {
+    const basePath = `${deviceId}.${forecastPath}`;
+    const fullBasePath = `${this.namespace}.${basePath}`;
+    try {
+      const objects = await this.getObjectListAsync({
+        startkey: `${fullBasePath}.`,
+        endkey: `${fullBasePath}.\u9999`,
+      });
+      const objectIds = (objects && objects.rows ? objects.rows : [])
+        .map((row) => row.id || (row.value && row.value._id))
+        .filter(Boolean);
+      const updates = getForecastRowValidityUpdates(objectIds, basePath, this.namespace, currentLength);
+      const timestamp = new Date().toISOString();
+
+      for (const update of updates) {
+        await this.setBooleanStateObject(`${update.root}.valid`, 'Forecast row is part of the latest response', update.valid);
+        await this.setBooleanStateObject(`${update.root}.stale`, 'Forecast row is stale', !update.valid);
+        if (update.valid) {
+          await this.setStringStateObject(`${update.root}.lastSeenInResponseAt`, 'Forecast row last seen in response at', timestamp);
+          await this.setStringStateObject(`${update.root}.staleSince`, 'Forecast row stale since', '');
+        } else {
+          const staleSinceState = await this.getStateAsync(`${update.root}.staleSince`);
+          if (!staleSinceState || !staleSinceState.val) {
+            await this.setStringStateObject(`${update.root}.staleSince`, 'Forecast row stale since', timestamp);
+          }
+        }
+      }
+    } catch (error) {
+      this.log.warn(`Could not update ${forecastPath} row metadata: ${error && error.message ? error.message : error}`);
+    }
+  }
+
+  async ensureChannelObject(id, name) {
+    await this.extendObjectAsync(id, {
+      type: 'channel',
+      common: {
+        name,
+      },
+      native: {},
+    });
+  }
+
+  async setNumberStateObject(id, name, value, unit = '', role = 'value') {
+    await this.extendObjectAsync(id, {
+      type: 'state',
+      common: {
+        name,
+        type: 'number',
+        role,
+        unit,
+        write: false,
+        read: true,
+      },
+      native: {},
+    });
+    await this.setStateAsync(id, value, true);
+  }
+
+  async setBooleanStateObject(id, name, value) {
+    await this.extendObjectAsync(id, {
+      type: 'state',
+      common: {
+        name,
+        type: 'boolean',
+        role: 'indicator',
+        write: false,
+        read: true,
+      },
+      native: {},
+    });
+    await this.setStateAsync(id, value, true);
+  }
+
+  async setStringStateObject(id, name, value) {
+    await this.extendObjectAsync(id, {
+      type: 'state',
+      common: {
+        name,
+        type: 'string',
+        role: 'text',
+        write: false,
+        read: true,
+      },
+      native: {},
+    });
+    await this.setStateAsync(id, value, true);
+  }
+
+  async writeNormalizedEnergyForecast(deviceId, todayRecords, tomorrowRecords) {
+    const normalized = normalizeEnergyForecast(todayRecords, tomorrowRecords, new Date());
+
+    await this.setNumberStateObject(`${deviceId}.todayWh`, 'Energy Forecast Today Total', Math.round(normalized.summary.todayWh), 'Wh', 'value.energy');
+    await this.setNumberStateObject(
+      `${deviceId}.todayRemainingWh`,
+      'Energy Forecast Today Remaining',
+      Math.round(normalized.summary.todayRemainingWh),
+      'Wh',
+      'value.energy',
+    );
+    await this.setNumberStateObject(`${deviceId}.tomorrowWh`, 'Energy Forecast Tomorrow Total', Math.round(normalized.summary.tomorrowWh), 'Wh', 'value.energy');
+
+    await this.ensureChannelObject(`${deviceId}.energyforecastSummary`, 'Energy Forecast Summary');
+    await this.setStringStateObject(`${deviceId}.energyforecastSummary.todayDate`, 'Forecast today date', normalized.todayDate);
+    await this.setStringStateObject(`${deviceId}.energyforecastSummary.tomorrowDate`, 'Forecast tomorrow date', normalized.tomorrowDate);
+    await this.setNumberStateObject(`${deviceId}.energyforecastSummary.todayWh`, 'Forecast today', normalized.summary.todayWh, 'Wh', 'value.energy');
+    await this.setNumberStateObject(`${deviceId}.energyforecastSummary.todayRemainingWh`, 'Forecast today remaining', normalized.summary.todayRemainingWh, 'Wh', 'value.energy');
+    await this.setNumberStateObject(`${deviceId}.energyforecastSummary.tomorrowWh`, 'Forecast tomorrow', normalized.summary.tomorrowWh, 'Wh', 'value.energy');
+    await this.setNumberStateObject(`${deviceId}.energyforecastSummary.recordCount`, 'Forecast raw record count', normalized.summary.recordCount, '', 'value');
+    await this.setStringStateObject(`${deviceId}.energyforecastSummary.updatedAt`, 'Forecast updated at', normalized.summary.updatedAt);
+    await this.setStringStateObject(`${deviceId}.energyforecastSummary.remainingUpdatedAt`, 'Forecast remaining updated at', normalized.summary.remainingUpdatedAt);
+
+    await this.ensureChannelObject(`${deviceId}.energyforecastToday15m`, 'Energy Forecast Today 15 Minutes');
+    for (const slot of normalized.today15m) {
+      const slotPath = `${deviceId}.energyforecastToday15m.${slot.label}`;
+      await this.ensureChannelObject(slotPath, `Today ${slot.label.replace('_', ':')}`);
+      await this.setNumberStateObject(`${slotPath}.value`, `Today ${slot.label.replace('_', ':')}`, slot.value, 'Wh', 'value.energy');
+    }
+
+    await this.ensureChannelObject(`${deviceId}.energyforecastTomorrowHourly`, 'Energy Forecast Tomorrow Hourly');
+    for (const slot of normalized.tomorrowHourly) {
+      const slotPath = `${deviceId}.energyforecastTomorrowHourly.${slot.label}`;
+      await this.ensureChannelObject(slotPath, `Tomorrow ${slot.label}:00`);
+      await this.setNumberStateObject(`${slotPath}.value`, `Tomorrow ${slot.label}:00`, slot.value, 'Wh', 'value.energy');
+    }
+  }
+
+  async updateEnergyForecastRemainingSummaries() {
+    for (const deviceId of this.deviceArray) {
+      try {
+        const todayDateState = await this.getStateAsync(`${deviceId}.energyforecastSummary.todayDate`);
+        if (!todayDateState || todayDateState.val !== formatLocalDate(new Date())) {
+          continue;
+        }
+
+        const dayStart = getLocalDayStart(new Date(), 0);
+        const todaySlots = [];
+        for (let index = 0; index < 96; index += 1) {
+          const start = new Date(dayStart.getTime() + index * 15 * 60 * 1000);
+          const end = new Date(start.getTime() + 15 * 60 * 1000);
+          const label = `${start.getHours().toString().padStart(2, '0')}_${start.getMinutes().toString().padStart(2, '0')}`;
+          const valueState = await this.getStateAsync(`${deviceId}.energyforecastToday15m.${label}.value`);
+          const value = Number(valueState && valueState.val);
+          todaySlots.push({
+            start,
+            end,
+            value: Number.isFinite(value) ? value : 0,
+          });
+        }
+
+        const now = new Date();
+        const remainingWh = calculateTodayRemainingFromSlots(todaySlots, now);
+        await this.setStateAsync(`${deviceId}.todayRemainingWh`, Math.round(remainingWh), true);
+        await this.setStateAsync(`${deviceId}.energyforecastSummary.todayRemainingWh`, remainingWh, true);
+        await this.setStateAsync(`${deviceId}.energyforecastSummary.remainingUpdatedAt`, now.toISOString(), true);
+      } catch (error) {
+        this.log.warn(`Could not update remaining energy forecast summary: ${error && error.message ? error.message : error}`);
+      }
+    }
+  }
+
   async refreshToken() {
     if (!this.session) {
       this.log.error('No session found relogin');
@@ -428,6 +564,7 @@ class FroniusSolarweb extends utils.Adapter {
       this.refreshTokenTimeout && clearTimeout(this.refreshTokenTimeout);
       this.updateInterval && clearInterval(this.updateInterval);
       this.refreshTokenInterval && clearInterval(this.refreshTokenInterval);
+      this.remainingForecastInterval && clearInterval(this.remainingForecastInterval);
       callback();
     } catch (e) {
       this.log.error('Error onUnload: ' + e);


### PR DESCRIPTION
## Zusammenfassung

Dieser PR ist auf den aktuellen `master` rebased und setzt auf der inzwischen vorhandenen GitHub-Version auf.

Die aktuelle Upstream-Version enthält bereits:

- getrennte Forecast-Abfragen für heute und morgen,
- einfache Summary-States `todayWh`, `todayRemainingWh` und `tomorrowWh`,
- eine Rohdaten-Bereinigung über `deleteBeforeUpdate`.

Dieser PR behält die kompakten Summary-States bei, ergänzt aber die für Automationen stabilere Normalisierung und ersetzt die komplette Forecast-Löschung durch Stale-/Valid-Metadaten auf den vorhandenen Raw-Zeilen.

Bezug: #4

## Motivation

Die Solar.web-API liefert Energy-Forecast-Daten je nach Abfragezeitpunkt in unterschiedlicher Granularität. Für Automationen und History ist es deshalb hilfreich, zusätzlich zu den Rohdaten stabile Raster zu haben.

Außerdem kann `deleteBeforeUpdate` zwar alte Rohdaten zuverlässig entfernen, löscht aber den kompletten Forecast-Objektbaum vor jedem Update. Dadurch können auf weiterhin gültigen Forecast-Objekten gesetzte ioBroker-Custom-Settings verloren gehen, z. B. History-/SQL-Konfigurationen.

Dieser PR löscht alte Raw-Index-Zeilen deshalb nicht mehr. Stattdessen werden vorhandene Zeilen anhand der letzten API-Antwort markiert:

- `valid=true` / `stale=false`, wenn die Zeile in der letzten Antwort enthalten war,
- `valid=false` / `stale=true`, wenn die Zeile nur noch aus einer älteren, längeren Antwort stammt,
- `lastSeenInResponseAt` für aktuell gelieferte Zeilen,
- `staleSince` für veraltete Zeilen.

Damit bleiben Custom-Settings auf den Raw-Objekten erhalten. Verbraucher können Stale-Zeilen erkennen; für einfache Automationen sind weiterhin die stabilen normalisierten States gedacht.

## Änderungen gegenüber aktuellem `master`

- Kompakte Summary-States bleiben erhalten:
  - `todayWh`
  - `todayRemainingWh`
  - `tomorrowWh`
- `todayRemainingWh` wird zusätzlich minütlich aus den vorhandenen Forecast-Slots aktualisiert.
- Der aktuell laufende Slot wird für `todayRemainingWh` anteilig berücksichtigt.
- Neue stabile normalisierte Datenpunkte:
  - `energyforecastToday15m.*.value`: 96 feste 15-Minuten-Slots für den heutigen lokalen Kalendertag.
  - `energyforecastTomorrowHourly.*.value`: 24 feste Stunden-Slots für den morgigen lokalen Kalendertag.
  - `energyforecastSummary.todayWh`
  - `energyforecastSummary.todayRemainingWh`
  - `energyforecastSummary.tomorrowWh`
  - `energyforecastSummary.recordCount`
  - `energyforecastSummary.updatedAt`
  - `energyforecastSummary.remainingUpdatedAt`
- Raw-Forecast-Zeilen werden über `valid`/`stale` markiert, statt bei kürzeren Antworten gelöscht zu werden.
- Normalisierungslogik in `lib/energyForecast.js` ausgelagert.
- Unit-Tests für Aggregation, Aufteilung, Tagesgrenzen, Resttagesberechnung und Stale-Metadaten ergänzt.
- README um die neuen Datenpunkte und Raw-Metadaten erweitert.

## Validierung

Erfolgreich:

- `node --check main.js`
- `node --check lib/energyForecast.js`
- `node --check energyForecast.test.js`
- `npm test`
- `npm run lint -- .`

Hinweis:

- `npm run check` schlägt weiterhin mit bereits vorhandenen TypeScript-/Typisierungsproblemen fehl, u. a. `axios.create`, fehlende Mocha-Typen und `@iobroker/testing`-Typauflösung. Diese Fehler sind nicht durch diesen PR eingeführt.
